### PR TITLE
Update CurlClient.php

### DIFF
--- a/src/HttpAdapter/CurlClient.php
+++ b/src/HttpAdapter/CurlClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Flutterwave\Adapter;
+namespace Flutterwave\HttpAdapter;
 
 use Psr\Http\Message\ResponseFactoryInterface;
 


### PR DESCRIPTION
namespace issues when running `compose dump-autoload`

file location **_vendor/flutterwavedev/flutterwave-v3/src\HttpAdapter\CurlClient.php_**

changes from line 3

`namespace Flutterwave\Adapter;`
to
 `namespace Flutterwave\HttpAdapter;`
