### PR TITLE
chore: fix Docker build context and dev environment setup

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     web:
         image: nginx:latest
+        platform: linux/amd64
         ports:
         - "80:80"
         volumes:
@@ -9,9 +10,15 @@ services:
         - app
     app:
         build:
-            context: .
-            dockerfile: ./php/Dockerfile
+            context: ..
+            dockerfile: .docker/php/Dockerfile
+        volumes:
+        - ..:/var/www/html
     db:
-        image: mysql:5.7
+        image: mysql:8.0
+        platform: linux/amd64
         volumes:
         - ./mysql:/var/lib/mysql
+        environment:
+            MYSQL_ROOT_PASSWORD: root
+            MYSQL_DATABASE: flutterwave

--- a/.docker/php/Dockerfile
+++ b/.docker/php/Dockerfile
@@ -23,13 +23,13 @@ COPY --from=composer:2.4 /usr/bin/composer /usr/bin/composer
 # This is enough to take advantage of docker cache and composer install will
 # be executed only when composer.json or composer.lock have indeed changed!-
 # https://medium.com/@softius/faster-docker-builds-with-composer-install-b4d2b15d0fff
-COPY ./app/composer.* ./
+COPY composer.* ./
 
 # install
 RUN composer install --prefer-dist --no-dev --no-scripts --no-progress --no-interaction
 
 # copy application files to the working directory
-COPY ./app .
+COPY . .
 
 # run composer dump-autoload --optimize
 RUN composer dump-autoload --optimize
@@ -45,7 +45,7 @@ FROM app as app_dev
 ENV XDEBUG_MODE=off
 
 # Copy xdebug config file into container
-COPY ./php/conf.d/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+COPY .docker/php/conf.d/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 
 # Install xdebug
 RUN set -eux; \


### PR DESCRIPTION
## Summary

Updates the Docker development environment to work with the repo root as
build context and fixes compatibility with Apple Silicon Macs.

## Changes

### `docker-compose.yml`
- Changed build context from `.` to `..` with `.docker/php/Dockerfile`
- Added volume mount (`..:/var/www/html`) for live reloading during development
- Upgraded MySQL from 5.7 to 8.0 (5.7 is EOL since Oct 2023 and has no ARM image)
- Added `platform: linux/amd64` for cross-architecture compatibility
- Added MySQL environment config (`MYSQL_ROOT_PASSWORD`, `MYSQL_DATABASE`)

### `php/Dockerfile`
- Updated COPY paths to reflect repo root context (`./app/composer.*` → `composer.*`, `./app .` → `. .`)
- Updated xdebug.ini COPY path to `.docker/php/conf.d/xdebug.ini`

## Note 
CI failures are unrelated to this PR — `SIGNOZ_API_KEY` and `SLACK_WEBHOOK_URL` secrets are not available on fork PRs.
